### PR TITLE
Support generation of svg files instead of png files

### DIFF
--- a/img.php
+++ b/img.php
@@ -13,7 +13,11 @@ $plugin = plugin_load('syntax', 'plantuml');
 $cache  = $plugin->_imgfile($data);
 
 if ($cache) {
-    header('Content-Type: image/png;');
+    if ($data['type'] == 'svg') {
+    	header('Content-Type: image/svg+xml;');
+    } else {
+    	header('Content-Type: image/png;');
+    }
     header('Expires: ' . gmdate('D, d M Y H:i:s', time() + max($conf['cachetime'], 3600)) . ' GMT');
     header('Cache-Control: public, proxy-revalidate, no-transform, max-age=' . max($conf['cachetime'], 3600));
     header('Pragma: public');

--- a/plugin.history.txt
+++ b/plugin.history.txt
@@ -1,3 +1,8 @@
+date    2015-12-28
+
+  * Support generation of SVG images instead of PNG for display on webpage. These can include links and scale well
+____
+
 date    2011-07-16
 
   * Fixed bug: PlantUML server rendering was not working due to encoding (slashes were converted to %2F and PlantUML doesn't like that)

--- a/syntax.php
+++ b/syntax.php
@@ -143,7 +143,7 @@ class syntax_plugin_plantuml extends DokuWiki_Syntax_Plugin {
                 if ($data['align'] == 'right') {
                     $renderer->doc .= ' align="right"';
                 }
-                $renderer->doc .= '/>';
+                $renderer->doc .= '></object>';
             } else {
                 $renderer->doc .= '<a title="' . $data['title'] . '" class="media" href="' . $img_unresized . '">';
                 $renderer->doc .= '<img src="' . $img . '" class="media' . $data['align'] . '" title="' . $data['title'] . '" alt="' . $data['title'] .  '"';
@@ -159,7 +159,7 @@ class syntax_plugin_plantuml extends DokuWiki_Syntax_Plugin {
                 if ($data['align'] == 'right') {
                     $renderer->doc .= ' align="right"';
                 }
-                $renderer->doc .= '/></a>';
+                $renderer->doc .= '></img></a>';
             }
             return true;
         } else if ($mode == 'odt') {

--- a/syntax.php
+++ b/syntax.php
@@ -145,21 +145,21 @@ class syntax_plugin_plantuml extends DokuWiki_Syntax_Plugin {
                 }
                 $renderer->doc .= '/>';
             } else {
-            $renderer->doc .= '<a title="' . $data['title'] . '" class="media" href="' . $img_unresized . '">';
-            $renderer->doc .= '<img src="' . $img . '" class="media' . $data['align'] . '" title="' . $data['title'] . '" alt="' . $data['title'] .  '"';
-            if ($data['width']) {
-                $renderer->doc .= ' width="' . $data['width'] . $data['percent'] . '"';
-            }
-            if ($data['height']) {
-                $renderer->doc .= ' height="' . $data['height'] . '"';
-            }
-            if ($data['align'] == 'left') {
-                $renderer-> doc .= ' align="left"';
-            }
-            if ($data['align'] == 'right') {
-                $renderer->doc .= ' align="right"';
-            }
-            $renderer->doc .= '/></a>';
+                $renderer->doc .= '<a title="' . $data['title'] . '" class="media" href="' . $img_unresized . '">';
+                $renderer->doc .= '<img src="' . $img . '" class="media' . $data['align'] . '" title="' . $data['title'] . '" alt="' . $data['title'] .  '"';
+                if ($data['width']) {
+                    $renderer->doc .= ' width="' . $data['width'] . $data['percent'] . '"';
+                }
+                if ($data['height']) {
+                    $renderer->doc .= ' height="' . $data['height'] . '"';
+                }
+                if ($data['align'] == 'left') {
+                    $renderer->doc .= ' align="left"';
+                }
+                if ($data['align'] == 'right') {
+                    $renderer->doc .= ' align="right"';
+                }
+                $renderer->doc .= '/></a>';
             }
             return true;
         } else if ($mode == 'odt') {


### PR DESCRIPTION
To use add type=svg to the uml declaration. Note this drops the link around the image since svg's can embed their own links specified in the plantuml data
